### PR TITLE
openshift-psap/ci-artifacts: use same branch for all OCP versions

### DIFF
--- a/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.4.yaml
+++ b/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.4.yaml
@@ -38,6 +38,6 @@ tests:
           memory: 2Gi
     workflow: ipi-aws
 zz_generated_metadata:
-  branch: release-4.4
+  branch: master
   org: openshift-psap
   repo: ci-artifacts

--- a/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.5.yaml
+++ b/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.5.yaml
@@ -38,6 +38,6 @@ tests:
           memory: 2Gi
     workflow: ipi-aws
 zz_generated_metadata:
-  branch: release-4.5
+  branch: master
   org: openshift-psap
   repo: ci-artifacts

--- a/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.7.yaml
+++ b/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.7.yaml
@@ -42,6 +42,6 @@ tests:
           memory: 2Gi
     workflow: ipi-aws
 zz_generated_metadata:
-  branch: release-4.7
+  branch: master
   org: openshift-psap
   repo: ci-artifacts

--- a/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.8.yaml
+++ b/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.8.yaml
@@ -41,6 +41,6 @@ tests:
           memory: 2Gi
     workflow: ipi-aws
 zz_generated_metadata:
-  branch: release-4.8
+  branch: master
   org: openshift-psap
   repo: ci-artifacts


### PR DESCRIPTION
Using draft mode to see if the merge passes the CI tests.